### PR TITLE
Update AIO POC for changes in attacher/provisioner/resizer

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: [ubuntu-latest]
     strategy:
       matrix:
-        go: ["1.22.3"]
+        go: ["1.23.1"]
     steps:
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
     - uses: actions/setup-go@v5

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ See https://docs.google.com/document/d/1z7OU79YBnvlaDgcvmtYVnUAYFX1w9lyrgiPTV7RX
 
 Requirements:
 
-- go 1.22.3
+- go 1.23.1
 
 ### Local Runs
 

--- a/hack/do_sync.sh
+++ b/hack/do_sync.sh
@@ -12,8 +12,8 @@ cond_exec() {
   echo $@
 }
 
-if [[ ! $(go version) =~ go1.22.3 ]]; then
-  echo "Install go1.22.3, please read the README.md"
+if [[ ! $(go version) =~ go1.23.1 ]]; then
+  echo "Install go1.23.1, please read the README.md"
   exit 1
 fi
 TRASH="trash"
@@ -30,7 +30,7 @@ for i in attacher,master provisioner,master resizer,master; do
     (cd pkg/${SIDECAR} && git checkout ${SIDECAR_HASH})
 
     cat pkg/${SIDECAR}/go.mod | grep "	" | grep -v "indirect" >> tmp/gomod-require.txt
-    cat pkg/${SIDECAR}/go.mod | grep "replace " >> tmp/gomod-replace.txt
+    cat pkg/${SIDECAR}/go.mod | { grep "replace " || [[ $? == 1 ]] } >> tmp/gomod-replace.txt
 
     ${TRASH} pkg/${SIDECAR}/.git
     ${TRASH} pkg/${SIDECAR}/.github
@@ -48,7 +48,7 @@ for i in attacher,master provisioner,master resizer,master; do
     (cd pkg/${SIDECAR}; find . -type f -exec grep -q "github.com/kubernetes-csi/external-${SIDECAR}/" --files-with-matches {} \; -print)
 
     (cd pkg/${SIDECAR}; find . -type f -exec grep -q "github.com/kubernetes-csi/external-${SIDECAR}/" --files-with-matches {} \; -print | \
-      xargs sed -i".bak" "s%github.com/kubernetes-csi/external-${SIDECAR}/%github.com/kubernetes-csi/csi-sidecars/pkg/${SIDECAR}/%g")
+	    xargs sed -E -i".bak" "s%github.com/kubernetes-csi/external-${SIDECAR}/(v[0-9]+/)?%github.com/kubernetes-csi/csi-sidecars/pkg/${SIDECAR}/%g")
   fi
 
   for FILE in pkg/${SIDECAR}/cmd/csi-${SIDECAR}/*.go; do
@@ -93,7 +93,7 @@ done
 cat <<EOF >go.mod
 module github.com/kubernetes-csi/csi-sidecars
 
-go 1.21
+go 1.23.1
 
 require (
 EOF

--- a/hack/main.go
+++ b/hack/main.go
@@ -26,7 +26,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	flag "github.com/spf13/pflag"
-	"sigs.k8s.io/sig-storage-lib-external-provisioner/v10/controller"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/v11/controller"
 
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	utilflag "k8s.io/component-base/cli/flag"
@@ -93,8 +93,9 @@ var (
 	preventVolumeModeConversion    = flag.Bool("provisioner-prevent-volume-mode-conversion", true, "Prevents an unauthorised user from modifying the volume mode when creating a PVC from an existing VolumeSnapshot.")
 	provisionController            *controller.ProvisionController
 
-	// Resizier specific
+	// Resizer specific
 	handleVolumeInUseError = flag.Bool("resizer-handle-volume-inuse-error", true, "Flag to turn on/off capability to handle volume in use error in resizer controller. Defaults to true if not set.")
+	extraModifyMetadata = flag.Bool("resizer-extra-modify-metadata", false, "If set, add pv/pvc metadata to plugin modify requests as parameters.")
 
 	featureGates map[string]bool
 	version      = "unknown"


### PR DESCRIPTION
### Summary
Updates the POC so it builds again for the newest version of the three sidecars:

- Make the `replace` grep optional as some sidecars no longer have any `replace` directives in their `go.mod`
- Remove trailing versions (e.g. `/v5`) in sidecar imports
- Bump go to 1.23.1
- Add `extraModifyMetadata` (new resizer parameter)
- Bump `sig-storage-lib-external-provisioner` to `v11`

### Testing
```bash
$ ./hack/do_cleanup.sh
+ TRASH=trash
+ command -v trash
+ TRASH='rm -rf'
+ rm -rf pkg cmd staging vendor go.mod go.sum go.work go.work.sum tmp

$ ./hack/do_sync.sh 
+ FROM_SCRATCH=false
++ go version
+ [[ ! go version go1.23.1 linux/amd64 =~ go1.23.1 ]]
+ TRASH=trash
+ command -v trash
+ TRASH='rm -rf'
+ mkdir -p tmp pkg cmd/csi-sidecars/ staging/src/github.com/kubernetes-csi/
+ for i in attacher,master provisioner,master resizer,master
+ IFS=,
+ read SIDECAR SIDECAR_HASH
+ [[ ! -d pkg/attacher ]]
+ git clone https://github.com/kubernetes-csi/external-attacher pkg/attacher
<... cut for brevity ...>
+ cd ./cmd/csi-sidecars
+ CGO_ENABLED=0
+ GOOS=
+ GOARCH=
+ go build -a -ldflags ' -X main.version=b7c831d8017e66ed1746903ba14a39ebaaec2f12 -extldflags "-static"' -o /home/conncatl/csi-sidecars-aio-poc/bin/csi-sidecars .
+ cat
+ cat

$ ./bin/csi-sidecars --controllers "resizer,attacher,provisioner"
I0501 13:50:41.096649  450822 resizer_main.go:61] "Version" version="b7c831d8017e66ed1746903ba14a39ebaaec2f12"
I0501 13:50:41.096728  450822 provisioner_csi-provisioner.go:88] "Version" version="b7c831d8017e66ed1746903ba14a39ebaaec2f12"
I0501 13:50:41.096743  450822 provisioner_csi-provisioner.go:111] Building kube configs for running in cluster...
F0501 13:50:41.096750  450822 provisioner_csi-provisioner.go:115] Failed to create config: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined
E0501 13:50:41.096737  450822 resizer_main.go:80] "Failed to create cluster config" err="unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined"
I0501 13:50:41.096703  450822 attacher_main.go:64] "Version" version="b7c831d8017e66ed1746903ba14a39ebaaec2f12"
```