### PR TITLE
Add the k8s.io matching dependency sanity check to compile the project

### DIFF
--- a/hack/do_sync.log
+++ b/hack/do_sync.log
@@ -17,11 +17,16 @@ Cloning into 'pkg/attacher'...
 + git checkout master
 Already on 'master'
 Your branch is up to date with 'origin/master'.
++ cd pkg/attacher
++ git rev-parse --short HEAD
+b58cdfc
 + cat pkg/attacher/go.mod
 + grep '	'
 + grep -v indirect
 + cat pkg/attacher/go.mod
 + grep 'replace '
++ cat pkg/attacher/go.mod
++ grep 'replace k8s.io/api =>'
 + trash pkg/attacher/.git
 + trash pkg/attacher/.github
 + trash pkg/attacher/vendor
@@ -50,6 +55,7 @@ Your branch is up to date with 'origin/master'.
 ./CHANGELOG/CHANGELOG-4.7.md
 ./CHANGELOG/CHANGELOG-2.2.md
 ./CHANGELOG/CHANGELOG-3.0.md
+./CHANGELOG/CHANGELOG-4.9.md
 ./CHANGELOG/CHANGELOG-1.2.md
 ./CHANGELOG/CHANGELOG-4.2.md
 ./CHANGELOG/CHANGELOG-2.0.md
@@ -60,6 +66,7 @@ Your branch is up to date with 'origin/master'.
 ./pkg/controller/csi_handler.go
 ./pkg/controller/trivial_handler_test.go
 ./pkg/controller/framework_test.go
+./pkg/controller/controller.go
 ./pkg/attacher/attacher_test.go
 + cd pkg/attacher
 + find . -type f -exec grep -q github.com/kubernetes-csi/external-attacher/ --files-with-matches '{}' ';' -print
@@ -79,6 +86,7 @@ Your branch is up to date with 'origin/master'.
 + sed -i.bak '/Options are:/d' cmd/csi-sidecars/attacher_main.go
 + sed -i.bak /logsapi.NewLoggingConfiguration/d cmd/csi-sidecars/attacher_main.go
 + sed -i.bak /logsapi.AddGoFlags/d cmd/csi-sidecars/attacher_main.go
++ sed -i.bak /logsapi.AddFlags/d cmd/csi-sidecars/attacher_main.go
 + sed -i.bak /logs.InitLogs/d cmd/csi-sidecars/attacher_main.go
 + sed -i.bak /flag.Parse/d cmd/csi-sidecars/attacher_main.go
 + sed -i.bak '/logsapi.ValidateAndApply/,/}/d' cmd/csi-sidecars/attacher_main.go
@@ -95,7 +103,7 @@ Your branch is up to date with 'origin/master'.
 + '[' attacher = resizer ']'
 + [[ attacher == \a\t\t\a\c\h\e\r ]]
 + rm pkg/attacher/cmd/csi-attacher/main.go
-+ symlink_from_hack_to_root hack/pkg/attacher/cmd/csi-attacher/main.go
++ symlink_from_root_to_hack hack/pkg/attacher/cmd/csi-attacher/main.go
 + file=hack/pkg/attacher/cmd/csi-attacher/main.go
 + file_without_hack=pkg/attacher/cmd/csi-attacher/main.go
 ++ dirname pkg/attacher/cmd/csi-attacher/main.go
@@ -111,11 +119,16 @@ Cloning into 'pkg/provisioner'...
 + git checkout master
 Already on 'master'
 Your branch is up to date with 'origin/master'.
++ cd pkg/provisioner
++ git rev-parse --short HEAD
+be69ca2
 + cat pkg/provisioner/go.mod
 + grep '	'
 + grep -v indirect
 + cat pkg/provisioner/go.mod
 + grep 'replace '
++ cat pkg/provisioner/go.mod
++ grep 'replace k8s.io/api =>'
 + trash pkg/provisioner/.git
 + trash pkg/provisioner/.github
 + trash pkg/provisioner/vendor
@@ -132,6 +145,7 @@ Your branch is up to date with 'origin/master'.
 + find . -type f -exec grep -q github.com/kubernetes-csi/external-provisioner/ --files-with-matches '{}' ';' -print
 ./cmd/csi-provisioner/csi-provisioner.go
 ./CHANGELOG/CHANGELOG-1.1.md
+./CHANGELOG/CHANGELOG-5.3.md
 ./CHANGELOG/CHANGELOG-3.1.md
 ./CHANGELOG/CHANGELOG-4.0.md
 ./CHANGELOG/CHANGELOG-3.3.md
@@ -175,6 +189,7 @@ Your branch is up to date with 'origin/master'.
 + sed -i.bak '/Options are:/d' cmd/csi-sidecars/provisioner_csi-provisioner.go
 + sed -i.bak /logsapi.NewLoggingConfiguration/d cmd/csi-sidecars/provisioner_csi-provisioner.go
 + sed -i.bak /logsapi.AddGoFlags/d cmd/csi-sidecars/provisioner_csi-provisioner.go
++ sed -i.bak /logsapi.AddFlags/d cmd/csi-sidecars/provisioner_csi-provisioner.go
 + sed -i.bak /logs.InitLogs/d cmd/csi-sidecars/provisioner_csi-provisioner.go
 + sed -i.bak /flag.Parse/d cmd/csi-sidecars/provisioner_csi-provisioner.go
 + sed -i.bak '/logsapi.ValidateAndApply/,/}/d' cmd/csi-sidecars/provisioner_csi-provisioner.go
@@ -204,6 +219,7 @@ Your branch is up to date with 'origin/master'.
 + sed -i.bak '/Options are:/d' cmd/csi-sidecars/provisioner_util.go
 + sed -i.bak /logsapi.NewLoggingConfiguration/d cmd/csi-sidecars/provisioner_util.go
 + sed -i.bak /logsapi.AddGoFlags/d cmd/csi-sidecars/provisioner_util.go
++ sed -i.bak /logsapi.AddFlags/d cmd/csi-sidecars/provisioner_util.go
 + sed -i.bak /logs.InitLogs/d cmd/csi-sidecars/provisioner_util.go
 + sed -i.bak /flag.Parse/d cmd/csi-sidecars/provisioner_util.go
 + sed -i.bak '/logsapi.ValidateAndApply/,/}/d' cmd/csi-sidecars/provisioner_util.go
@@ -233,6 +249,7 @@ Your branch is up to date with 'origin/master'.
 + sed -i.bak '/Options are:/d' cmd/csi-sidecars/provisioner_util_test.go
 + sed -i.bak /logsapi.NewLoggingConfiguration/d cmd/csi-sidecars/provisioner_util_test.go
 + sed -i.bak /logsapi.AddGoFlags/d cmd/csi-sidecars/provisioner_util_test.go
++ sed -i.bak /logsapi.AddFlags/d cmd/csi-sidecars/provisioner_util_test.go
 + sed -i.bak /logs.InitLogs/d cmd/csi-sidecars/provisioner_util_test.go
 + sed -i.bak /flag.Parse/d cmd/csi-sidecars/provisioner_util_test.go
 + sed -i.bak '/logsapi.ValidateAndApply/,/}/d' cmd/csi-sidecars/provisioner_util_test.go
@@ -258,12 +275,16 @@ Cloning into 'pkg/resizer'...
 + git checkout master
 Already on 'master'
 Your branch is up to date with 'origin/master'.
++ cd pkg/resizer
++ git rev-parse --short HEAD
+d6833d0
 + cat pkg/resizer/go.mod
 + grep '	'
 + grep -v indirect
 + cat pkg/resizer/go.mod
 + grep 'replace '
-+ [[ 1 == 1 ]]
++ cat pkg/resizer/go.mod
++ grep 'replace k8s.io/api =>'
 + trash pkg/resizer/.git
 + trash pkg/resizer/.github
 + trash pkg/resizer/vendor
@@ -330,6 +351,7 @@ Your branch is up to date with 'origin/master'.
 + sed -i.bak '/Options are:/d' cmd/csi-sidecars/resizer_main.go
 + sed -i.bak /logsapi.NewLoggingConfiguration/d cmd/csi-sidecars/resizer_main.go
 + sed -i.bak /logsapi.AddGoFlags/d cmd/csi-sidecars/resizer_main.go
++ sed -i.bak /logsapi.AddFlags/d cmd/csi-sidecars/resizer_main.go
 + sed -i.bak /logs.InitLogs/d cmd/csi-sidecars/resizer_main.go
 + sed -i.bak /flag.Parse/d cmd/csi-sidecars/resizer_main.go
 + sed -i.bak '/logsapi.ValidateAndApply/,/}/d' cmd/csi-sidecars/resizer_main.go
@@ -346,217 +368,21 @@ Your branch is up to date with 'origin/master'.
 + '[' resizer = resizer ']'
 + sed -i.bak /strings/d cmd/csi-sidecars/resizer_main.go
 + [[ resizer == \a\t\t\a\c\h\e\r ]]
-+ symlink_from_hack_to_root hack/cmd/csi-sidecars/main.go
-+ file=hack/cmd/csi-sidecars/main.go
-+ file_without_hack=cmd/csi-sidecars/main.go
-++ dirname cmd/csi-sidecars/main.go
-+ mkdir -p cmd/csi-sidecars
-+ ln -s /home/mauriciopoppe.linux/go/src/github.com/mauriciopoppe/csi-sidecars-aio-poc/hack/cmd/csi-sidecars/main.go /home/mauriciopoppe.linux/go/src/github.com/mauriciopoppe/csi-sidecars-aio-poc/cmd/csi-sidecars/main.go
-+ symlink_from_hack_to_root hack/cmd/csi-sidecars/config/flags.go
-+ file=hack/cmd/csi-sidecars/config/flags.go
-+ file_without_hack=cmd/csi-sidecars/config/flags.go
-++ dirname cmd/csi-sidecars/config/flags.go
-+ mkdir -p cmd/csi-sidecars/config
-+ ln -s /home/mauriciopoppe.linux/go/src/github.com/mauriciopoppe/csi-sidecars-aio-poc/hack/cmd/csi-sidecars/config/flags.go /home/mauriciopoppe.linux/go/src/github.com/mauriciopoppe/csi-sidecars-aio-poc/cmd/csi-sidecars/config/flags.go
-+ symlink_from_hack_to_root hack/pkg/attacher/cmd/csi-attacher/config/flags.go
-+ file=hack/pkg/attacher/cmd/csi-attacher/config/flags.go
-+ file_without_hack=pkg/attacher/cmd/csi-attacher/config/flags.go
-++ dirname pkg/attacher/cmd/csi-attacher/config/flags.go
-+ mkdir -p pkg/attacher/cmd/csi-attacher/config
-+ ln -s /home/mauriciopoppe.linux/go/src/github.com/mauriciopoppe/csi-sidecars-aio-poc/hack/pkg/attacher/cmd/csi-attacher/config/flags.go /home/mauriciopoppe.linux/go/src/github.com/mauriciopoppe/csi-sidecars-aio-poc/pkg/attacher/cmd/csi-attacher/config/flags.go
-+ cat
-+ cat tmp/gomod-require.txt
-+ sort
-+ uniq
-+ cat
-+ cat tmp/gomod-replace.txt
-+ sort
-+ uniq
-+ go mod tidy
-+ cat
-+ csi_lib_utils=staging/src/github.com/kubernetes-csi/csi-lib-utils
-+ [[ ! -d staging/src/github.com/kubernetes-csi/csi-lib-utils ]]
-+ git clone https://github.com/kubernetes-csi/csi-lib-utils staging/src/github.com/kubernetes-csi/csi-lib-utils
-Cloning into 'staging/src/github.com/kubernetes-csi/csi-lib-utils'...
-+ trash staging/src/github.com/kubernetes-csi/csi-lib-utils/.git
-+ trash staging/src/github.com/kubernetes-csi/csi-lib-utils/.github
-+ trash staging/src/github.com/kubernetes-csi/csi-lib-utils/vendor
-+ trash staging/src/github.com/kubernetes-csi/csi-lib-utils/release-tools
-+ grep -q ./staging/src/github.com/kubernetes-csi/csi-lib-utils go.mod
-+ echo 'replace github.com/kubernetes-csi/csi-lib-utils => ./staging/src/github.com/kubernetes-csi/csi-lib-utils'
-+ trash go.work go.sum
-+ go work init .
-+ go work use ./staging/src/github.com/kubernetes-csi/csi-lib-utils
-+ go mod tidy
-+ go work vendor
-+ make build
-./release-tools/verify-go-version.sh "go"
-
-======================================================
-                  WARNING
-
-  This projects is tested with Go v1.22.3.
-  Your current Go version is v1.24.
-  This may or may not be close enough.
-
-  In particular test-gofmt and test-vendor
-  are known to be sensitive to the version of
-  Go.
-======================================================
-
-mkdir -p bin
-# os_arch_seen captures all of the $os-$arch-$buildx_platform seen for the current binary
-# that we want to build, if we've seen an $os-$arch-$buildx_platform before it means that
-# we don't need to build it again, this is done to avoid building
-# the windows binary multiple times (see the default value of $BUILD_PLATFORMS)
-export os_arch_seen="" && echo '' | tr ';' '\n' | while read -r os arch buildx_platform suffix base_image addon_image; do \
-	os_arch_seen_pre=${os_arch_seen%%$os-$arch-$buildx_platform*}; \
-	if ! [ ${#os_arch_seen_pre} = ${#os_arch_seen} ]; then \
-		continue; \
-	fi; \
-	if ! (set -x; cd ./cmd/csi-sidecars && CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" go build  -a -ldflags ' -X main.version=f4bfe4de25a20af969687d311cfba3455e82fd5f -extldflags "-static"' -o "/home/mauriciopoppe.linux/go/src/github.com/mauriciopoppe/csi-sidecars-aio-poc/bin/csi-sidecars$suffix" .); then \
-		echo "Building csi-sidecars for GOOS=$os GOARCH=$arch failed, see error(s) above."; \
-		exit 1; \
-	fi; \
-	os_arch_seen+=";$os-$arch-$buildx_platform"; \
-done
-+ cd ./cmd/csi-sidecars
-+ CGO_ENABLED=0
-+ GOOS=
-+ GOARCH=
-+ go build -a -ldflags ' -X main.version=f4bfe4de25a20af969687d311cfba3455e82fd5f -extldflags "-static"' -o /home/mauriciopoppe.linux/go/src/github.com/mauriciopoppe/csi-sidecars-aio-poc/bin/csi-sidecars .
-+ ./bin/csi-sidecars --help
-Usage of ./bin/csi-sidecars:
-      --add_dir_header                                    If true, adds the file directory to the header of the log messages
-      --alsologtostderr                                   log to standard error as well as files (no effect when -logtostderr=true)
-      --attacher-default-fstype string                    The default filesystem type of the volume to use.
-      --attacher-max-entries int                          Max entries per each page in volume lister call, 0 means no limit.
-      --attacher-max-grpc-log-length int                  The maximum amount of characters logged for every grpc responses. Defaults to no limit (default -1)
-      --attacher-reconcile-sync duration                  Resync interval of the VolumeAttachment reconciler. (default 1m0s)
-      --attacher-timeout duration                         Timeout for waiting for attaching or detaching the volume. (default 15s)
-      --attacher-worker-threads int                       Number of worker threads per sidecar (default 10)
-      --automaxprocs boolFunc[=true]                      automatically set GOMAXPROCS to match Linux container CPU quota
-      --controllers string                                A comma-separated list of controllers to enable. The possible values are: [resizer,attacher,provisioner]
-      --csi-address string                                The gRPC endpoint for Target CSI Volume. (default "/run/csi/socket")
-      --feature-gates mapStringBool                       A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:
-                                                          AllAlpha=true|false (ALPHA - default=false)
-                                                          AllBeta=true|false (BETA - default=false)
-                                                          AnnotateFsResize=true|false (ALPHA - default=false)
-                                                          CrossNamespaceVolumeDataSource=true|false (ALPHA - default=false)
-                                                          RecoverVolumeExpansionFailure=true|false (BETA - default=true)
-                                                          VolumeAttributesClass=true|false (BETA - default=false)
-      --http-endpoint :8080                               The TCP network address where the HTTP server for diagnostics, including metrics and leader election health check, will listen (example: :8080). The default is empty string, which means the server is disabled. Only one of `--metrics-address` and `--http-endpoint` can be set.
-      --kube-api-burst int                                Burst to use while communicating with the kubernetes apiserver. Defaults to 10. (default 10)
-      --kube-api-qps float                                QPS to use while communicating with the kubernetes apiserver. Defaults to 5.0. (default 5)
-      --kubeconfig string                                 Absolute path to the kubeconfig file. Required only when running out of cluster.
-      --leader-election                                   Enable leader election.
-      --leader-election-lease-duration duration           Duration, in seconds, that non-leader candidates will wait to force acquire leadership. Defaults to 15 seconds. (default 15s)
-      --leader-election-namespace string                  Namespace where the leader election resource lives. Defaults to the pod namespace if not set.
-      --leader-election-renew-deadline duration           Duration, in seconds, that the acting leader will retry refreshing leadership before giving up. Defaults to 10 seconds. (default 10s)
-      --leader-election-retry-period duration             Duration, in seconds, the LeaderElector clients should wait between tries of actions. Defaults to 5 seconds. (default 5s)
-      --log_backtrace_at traceLocation                    when logging hits line file:N, emit a stack trace (default :0)
-      --log_dir string                                    If non-empty, write log files in this directory (no effect when -logtostderr=true)
-      --log_file string                                   If non-empty, use this log file (no effect when -logtostderr=true)
-      --log_file_max_size uint                            Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
-      --logtostderr                                       log to standard error instead of files (default true)
-      --master string                                     Master URL to build a client config from. Either this or kubeconfig needs to be set if the provisioner is being run out of cluster.
-      --metrics-address :8080                             (deprecated) The TCP network address where the prometheus metrics endpoint will listen (example: :8080). The default is empty string, which means metrics endpoint is disabled. Only one of `--metrics-address` and `--http-endpoint` can be set.
-      --metrics-path /metrics                             The HTTP path where prometheus metrics will be exposed. Default is /metrics. (default "/metrics")
-      --one_output                                        If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
-      --provisioner-capacity-for-immediate-binding        Enables producing capacity information for storage classes with immediate binding. Not needed for the Kubernetes scheduler, maybe useful for other consumers or for debugging.
-      --provisioner-capacity-ownerref-level int           The level indicates the number of objects that need to be traversed starting from the pod identified by the POD_NAME and NAMESPACE environment variables to reach the owning object for CSIStorageCapacity objects: -1 for no owner, 0 for the pod itself, 1 for a StatefulSet or DaemonSet, 2 for a Deployment, etc. (default 1)
-      --provisioner-capacity-poll-interval duration       How long the external-provisioner waits before checking for storage capacity changes. (default 1m0s)
-      --provisioner-capacity-threads uint                 Number of simultaneously running threads, handling CSIStorageCapacity objects (default 1)
-      --provisioner-cloning-protection-threads uint       Number of simultaneously running threads, handling cloning finalizer removal (default 1)
-      --provisioner-controller-publish-readonly           This option enables PV to be marked as readonly at controller publish volume call if PVC accessmode has been set to ROX.
-      --provisioner-enable-capacity                       This enables producing CSIStorageCapacity objects with capacity information from the driver's GetCapacity call.
-      --provisioner-enable-pprof /debug/pprof/            Enable pprof profiling on the TCP network address specified by --http-endpoint. The HTTP path is /debug/pprof/.
-      --provisioner-extra-create-metadata                 If set, add pv/pvc metadata to plugin create requests as parameters.
-      --provisioner-immediate-topology                    Immediate binding: pass aggregated cluster topologies for all nodes where the CSI driver is available (enabled, the default) or no topology requirements (if disabled). (default true)
-      --provisioner-kube-api-capacity-burst int           Burst to use for storage capacity updates while communicating with the kubernetes apiserver. Defaults to 5. (default 5)
-      --provisioner-kube-api-capacity-qps float32         QPS to use for storage capacity updates while communicating with the kubernetes apiserver. Defaults to 1.0. (default 1)
-      --provisioner-node-deployment                       Enables deploying the external-provisioner together with a CSI driver on nodes to manage node-local volumes.
-      --provisioner-node-deployment-base-delay duration   Determines how long the external-provisioner sleeps initially before trying to own a PVC with immediate binding. (default 20s)
-      --provisioner-node-deployment-immediate-binding     Determines whether immediate binding is supported when deployed on each node. (default true)
-      --provisioner-node-deployment-max-delay duration    Determines how long the external-provisioner sleeps at most before trying to own a PVC with immediate binding. (default 1m0s)
-      --provisioner-prevent-volume-mode-conversion        Prevents an unauthorised user from modifying the volume mode when creating a PVC from an existing VolumeSnapshot. (default true)
-      --provisioner-strict-topology                       Late binding: pass only selected node topology to CreateVolume Request, unlike default behavior of passing aggregated cluster topologies that match with topology keys of the selected node.
-      --provisioner-volume-name-prefix string             Prefix to apply to the name of a created volume. (default "pvc")
-      --provisioner-volume-name-uuid-length int           Truncates generated UUID of a created volume to this length. Defaults behavior is to NOT truncate. (default -1)
-      --resizer-extra-modify-metadata                     If set, add pv/pvc metadata to plugin modify requests as parameters.
-      --resizer-handle-volume-inuse-error                 Flag to turn on/off capability to handle volume in use error in resizer controller. Defaults to true if not set. (default true)
-      --resync duration                                   Resync interval of the controller. (default 10m0s)
-      --retry-interval-max duration                       Maximum retry interval of failed create volume or deletion. (default 5m0s)
-      --retry-interval-start duration                     Initial retry interval of failed create volume or deletion. It doubles with each failure, up to retry-interval-max. (default 1s)
-      --skip_headers                                      If true, avoid header prefixes in the log messages
-      --skip_log_headers                                  If true, avoid headers when opening log files (no effect when -logtostderr=true)
-      --stderrthreshold severity                          logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true) (default 2)
-  -v, --v Level                                           number for the log level verbosity
-      --version                                           Show version.
-      --vmodule moduleSpec                                comma-separated list of pattern=N settings for file-filtered logging
-pflag: help requested
-+ true
-+ go build -a -ldflags ' -X main.version=foo -extldflags "-static"' -o ./bin/csi-attacher ./pkg/attacher/cmd/csi-attacher
-+ ./bin/csi-attacher --help
-Usage of ./bin/csi-attacher:
-  -csi-address string
-    	Address of the CSI driver socket. (default "/run/csi/socket")
-  -default-fstype string
-    	The default filesystem type of the volume to use.
-  -http-endpoint :8080
-    	The TCP network address where the HTTP server for diagnostics, including metrics and leader election health check, will listen (example: :8080). The default is empty string, which means the server is disabled. Only one of `--metrics-address` and `--http-endpoint` can be set.
-  -kube-api-burst int
-    	Burst to use while communicating with the kubernetes apiserver. Defaults to 10. (default 10)
-  -kube-api-qps float
-    	QPS to use while communicating with the kubernetes apiserver. Defaults to 5.0. (default 5)
-  -kubeconfig string
-    	Absolute path to the kubeconfig file. Required only when running out of cluster.
-  -leader-election
-    	Enable leader election.
-  -leader-election-lease-duration duration
-    	Duration, in seconds, that non-leader candidates will wait to force acquire leadership. Defaults to 15 seconds. (default 15s)
-  -leader-election-namespace string
-    	Namespace where the leader election resource lives. Defaults to the pod namespace if not set.
-  -leader-election-renew-deadline duration
-    	Duration, in seconds, that the acting leader will retry refreshing leadership before giving up. Defaults to 10 seconds. (default 10s)
-  -leader-election-retry-period duration
-    	Duration, in seconds, the LeaderElector clients should wait between tries of actions. Defaults to 5 seconds. (default 5s)
-  -log-flush-frequency duration
-    	Maximum number of seconds between log flushes (default 5s)
-  -log-json-info-buffer-size value
-    	[Alpha] In JSON format with split output streams, the info messages can be buffered for a while to increase performance. The default value of zero bytes disables buffering. The size can be specified as number of bytes (512), multiples of 1000 (1K), multiples of 1024 (2Ki), or powers of those (3M, 4G, 5Mi, 6Gi). Enable the LoggingAlphaOptions feature gate to use this.
-  -log-json-split-stream
-    	[Alpha] In JSON format, write error messages to stderr and info messages to stdout. The default is to write a single stream to stdout. Enable the LoggingAlphaOptions feature gate to use this.
-  -log-text-info-buffer-size value
-    	[Alpha] In text format with split output streams, the info messages can be buffered for a while to increase performance. The default value of zero bytes disables buffering. The size can be specified as number of bytes (512), multiples of 1000 (1K), multiples of 1024 (2Ki), or powers of those (3M, 4G, 5Mi, 6Gi). Enable the LoggingAlphaOptions feature gate to use this.
-  -log-text-split-stream
-    	[Alpha] In text format, write error messages to stderr and info messages to stdout. The default is to write a single stream to stdout. Enable the LoggingAlphaOptions feature gate to use this.
-  -logging-format string
-    	Sets the log format. Permitted formats: "json" (gated by LoggingBetaOptions), "text". (default "text")
-  -max-entries int
-    	Max entries per each page in volume lister call, 0 means no limit.
-  -max-grpc-log-length int
-    	The maximum amount of characters logged for every grpc responses. Defaults to no limit (default -1)
-  -metrics-address :8080
-    	(deprecated) The TCP network address where the prometheus metrics endpoint will listen (example: :8080). The default is empty string, which means metrics endpoint is disabled. Only one of `--metrics-address` and `--http-endpoint` can be set.
-  -metrics-path /metrics
-    	The HTTP path where prometheus metrics will be exposed. Default is /metrics. (default "/metrics")
-  -reconcile-sync duration
-    	Resync interval of the VolumeAttachment reconciler. (default 1m0s)
-  -resync duration
-    	Resync interval of the controller. (default 10m0s)
-  -retry-interval-max duration
-    	Maximum retry interval of failed create volume or deletion. (default 5m0s)
-  -retry-interval-start duration
-    	Initial retry interval of failed create volume or deletion. It doubles with each failure, up to retry-interval-max. (default 1s)
-  -timeout duration
-    	Timeout for waiting for attaching or detaching the volume. (default 15s)
-  -v value
-    	number for the log level verbosity
-  -version
-    	Show version.
-  -vmodule value
-    	comma-separated list of pattern=N settings for file-filtered logging (only works for text log format)
-  -worker-threads int
-    	Number of worker threads per sidecar (default 10)
-+ cat
++ echo 'Sanity checks'
+Sanity checks
++ echo 'Check that the k8s.io dependencies match'
+Check that the k8s.io dependencies match
+++ cat tmp/gomod-k8sapi.txt
+++ sort
+++ uniq
+++ wc -l
++ [[ 2 -gt 1 ]]
++ echo 'There are multiple k8s.io versions as dependencies from sidecars!'
+There are multiple k8s.io versions as dependencies from sidecars!
++ echo 'Check the go.mod of each sidecar and verify that the k8s.io dependecies match'
+Check the go.mod of each sidecar and verify that the k8s.io dependecies match
++ cat tmp/gomod-k8sapi.txt
+replace k8s.io/api => k8s.io/api v0.34.0
+replace k8s.io/api => k8s.io/api v0.33.0
+replace k8s.io/api => k8s.io/api v0.34.0
++ exit 1


### PR DESCRIPTION
Both presubmits should fail because currently:

- attacher uses k8s.io/api v0.34
- provisioner uses k8s.io/api v0.33
- resize uses k8s.io/api v0.34

Therefore the project can't be compiled. I added a sanity check to check this drift.